### PR TITLE
fix(UI): removes hanging item from state

### DIFF
--- a/src/fuzzy-picker.js
+++ b/src/fuzzy-picker.js
@@ -73,11 +73,13 @@ export default class FuzzyPicker extends React.Component {
       case 'Enter': { // Enter key
         let item = this.state.items[this.state.selectedIndex];
         if (item) {
+          this.setState({items: this.getInitialItems()});
           this.props.onChange(item);
         }
         break;
       }
       case 'Escape': {
+        this.setState({items: this.getInitialItems()});
         this.props.onClose();
       }
     }


### PR DESCRIPTION
In the current implementation when the fuzzy-picker is reopened after being closed whether by ESC or by Enter, the previous list remains. This is not standard among other fuzzy switchers.

![Fuzzy-picker example](https://i.gyazo.com/6ec4a0a78c8087228d626b38017a5a5e.gif)
![slack example](https://i.gyazo.com/8f6879da4b56a406796d9dda52ca476a.gif)

I'm happy to make changes or have discussion.

-------

Why was this necessary?
- keeps fuzzy-switcher's functionality similar to slacks and sublimes

How does this address the issue?
- when the user presses 'esc' or 'enter' the fuzzy-switcher will clear
  the items on state so that when it is reopened there will be a clear
  display again, as if opening it for the first time

What side effects does this change have?
- the function name 'getInitialItems' is potentially confusing now.