### PR TITLE
Limit number of displayed items on initial load with showAllItems

### DIFF
--- a/src/fuzzy-picker.js
+++ b/src/fuzzy-picker.js
@@ -113,7 +113,7 @@ export default class FuzzyPicker extends React.Component {
       this.setState({items: items.slice(0, this.props.displayCount), selectedIndex: 0});
     } else {
       // initially, show an empty picker or all items.
-      this.setState({items: this.getInitialItems(this.props), selectedIndex: 0});
+      this.setState({items: this.getInitialItems(this.props).slice(0, this.props.displayCount), selectedIndex: 0});
     }
   }
 


### PR DESCRIPTION
When showAllItems=true,  any number of items is viewed. Ideally, this should be upper bounded by the same number as during normal operation (displayCount prop).