### PR TITLE
Don't clean items on enter if autoCloseOnEnter is disabled

### DIFF
--- a/src/fuzzy-picker.js
+++ b/src/fuzzy-picker.js
@@ -73,9 +73,9 @@ export default class FuzzyPicker extends React.Component {
       case 'Enter': { // Enter key
         let item = this.state.items[this.state.selectedIndex];
         if (item) {
-          this.setState({items: this.getInitialItems(this.props)});
           this.props.onChange(item);
           if (this.props.autoCloseOnEnter) {
+            this.setState({items: this.getInitialItems(this.props)});
             this.props.onClose();
           }
         }


### PR DESCRIPTION
If autoCloseOnEnter is disabled, the picker stays open with user text typed in when user presses enter, so it makes sense to leave their selection.